### PR TITLE
Update download link for GNOME OS 3.38

### DIFF
--- a/data/osinfo/gnome-3.38.xml
+++ b/data/osinfo/gnome-3.38.xml
@@ -42,7 +42,7 @@
 
     <media arch="x86_64">
       <variant id="stable"/>
-      <url>https://os.gnome.org/download/3.38.0/gnome_os_installer.iso</url>
+      <url>https://download.gnome.org/gnomeos/3.38.0/gnome_os_installer.iso</url>
       <iso>
         <volume-id>GNOME-OS-3.38-x86_64</volume-id>
       </iso>


### PR DESCRIPTION
updated the link to the copy hosted on download.gnome.org, as the iso on os.gnome.org is no longer accessible 